### PR TITLE
Knic/timed stale cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The features:
 - You can control your own blinds/roller shutters apparatus with three minimalistic HTTP requests.
 - The control is not a simple binary open/close: **it support percentages**. You can open your blinds at 50% or 65% for instance.
 - Your blinds can still be manually operated. As long at the `get_current_position_url` returns the right value, this plugin will update iOS Home app in real time.
+- Instant reporting using cached data if no recent (`no_cache_duration_millis`) app detected activity.
 
 ### Who is it for?
 
@@ -80,7 +81,8 @@ Here are them all with their default values.
     "get_current_state_expected_response_code": "200",
     
     "get_current_position_polling_millis": "500",
-    "get_current_state_polling_millis": "500"
+    "get_current_state_polling_millis": "500",
+    "no_cache_duration_millis": "60000"
 }
 ````
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ function MinimalisticHttpBlinds(log, config) {
     this.get_current_state_callbacks = [];
 
     // Initializing things
-    this.start_current_position_polling();
-    this.start_current_state_polling();
+    setInterval(this.update_current_position.bind(this), this.get_current_position_polling_millis);
+    setInterval(this.update_current_state.bind(this), this.get_current_state_polling_millis);
+
     this.init_service();
 }
 
@@ -65,14 +66,6 @@ MinimalisticHttpBlinds.prototype.init_service = function() {
     }.bind(this));
 };
 
-MinimalisticHttpBlinds.prototype.start_current_position_polling = function() {
-    setTimeout(this.update_current_position.bind(this), this.get_current_position_polling_millis);
-};
-
-MinimalisticHttpBlinds.prototype.start_current_state_polling = function() {
-    setTimeout(this.update_current_state.bind(this), this.get_current_state_polling_millis);
-};
-
 MinimalisticHttpBlinds.prototype.update_current_position = function() {
     request({
         url: this.get_current_position_url,
@@ -82,12 +75,10 @@ MinimalisticHttpBlinds.prototype.update_current_position = function() {
         if (error) {
             this.log('Error when polling current position.');
             this.log(error);
-            this.start_current_position_polling();
             return;
         }
         else if (response.statusCode != this.get_current_position_expected_response_code) {
             this.log('Unexpected HTTP status code when polling current position. Got: ' + response.statusCode + ', expected:' + this.get_current_position_expected_response_code);
-            this.start_current_position_polling();
             return;
         }
 
@@ -117,7 +108,6 @@ MinimalisticHttpBlinds.prototype.update_current_position = function() {
         }
 
         this.current_position = new_position;
-        this.start_current_position_polling();
     }.bind(this));
 };
 
@@ -130,12 +120,10 @@ MinimalisticHttpBlinds.prototype.update_current_state = function() {
         if (error) {
             this.log('Error when polling current state.');
             this.log(error);
-            this.start_current_position_polling();
             return;
         }
         else if (response.statusCode != this.get_current_state_expected_response_code) {
             this.log('Unexpected HTTP status code when polling current state. Got: ' + response.statusCode + ', expected:' + this.get_current_state_expected_response_code);
-            this.start_current_position_polling();
             return;
         }
 
@@ -172,7 +160,6 @@ MinimalisticHttpBlinds.prototype.update_current_state = function() {
         }
 
         this.current_state = new_state;
-        this.start_current_state_polling();
     }.bind(this));
 };
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ function MinimalisticHttpBlinds(log, config) {
     // Internal fields
     this.current_position = undefined;
     this.current_state = undefined;
+    this.current_position = 100;
+    this.current_state = 2;
 
     this.get_current_position_callbacks = [];
     this.get_target_position_callbacks = [];
@@ -75,22 +77,20 @@ MinimalisticHttpBlinds.prototype.update_current_position = function() {
         if (error) {
             this.log('Error when polling current position.');
             this.log(error);
+            this.complete_get_current_position_callbacks(this.current_position);
             return;
         }
         else if (response.statusCode != this.get_current_position_expected_response_code) {
             this.log('Unexpected HTTP status code when polling current position. Got: ' + response.statusCode + ', expected:' + this.get_current_position_expected_response_code);
+            this.complete_get_current_position_callbacks(this.current_position);
             return;
         }
 
         var new_position = parseInt(body);
 
+
         if (this.get_current_position_callbacks.length > 0) {
-            this.get_current_position_callbacks.forEach(function (callback) {
-                this.log('calling callback with position: ' + new_position);
-                callback(null, new_position);
-            }.bind(this));
-            this.log('Responded to ' + this.get_current_position_callbacks.length + ' CurrentPosition callbacks!');
-            this.get_current_position_callbacks = [];
+            this.complete_get_current_position_callbacks(new_position);
         }
         else if (new_position !== this.current_position && !this.notify_ios_blinds_has_stopped) {
             this.service.getCharacteristic(Characteristic.CurrentPosition).setValue(new_position);
@@ -111,6 +111,56 @@ MinimalisticHttpBlinds.prototype.update_current_position = function() {
     }.bind(this));
 };
 
+MinimalisticHttpBlinds.prototype.complete_get_current_position_callbacks = function(position) {
+    
+    if (this.get_current_position_callbacks.length > 0) {
+        this.get_current_position_callbacks.forEach(function (callback) {
+            this.log('calling callback with position: ' + position);
+            callback(null, position);
+        }.bind(this));
+        this.log('Responded to ' + this.get_current_position_callbacks.length + ' CurrentPosition callbacks!');
+        this.get_current_position_callbacks = [];
+    }
+}
+
+MinimalisticHttpBlinds.prototype.complete_get_current_state_callbacks = function(state) {
+    
+    if (this.get_current_state_callbacks.length > 0) {
+        this.get_current_state_callbacks.forEach(function (callback) {
+            callback(null, state);
+        }.bind(this));
+        this.log('Responded to ' + this.get_current_state_callbacks.length + ' PositionState callbacks!');
+        this.get_current_state_callbacks = [];
+    }
+}
+
+MinimalisticHttpBlinds.prototype.complete_get_current_state_callbacks = function(state) {
+    
+    if (this.get_current_state_callbacks.length > 0) {
+        this.get_current_state_callbacks.forEach(function (callback) {
+            callback(null, state);
+        }.bind(this));
+        this.log('Responded to ' + this.get_current_state_callbacks.length + ' PositionState callbacks!');
+        this.get_current_state_callbacks = [];
+    }
+}
+
+MinimalisticHttpBlinds.prototype.complete_get_target_position_callbacks = function(state) {
+    // This is ugly: we're faking the target position to either 0, 100 or the current position,
+    // so that iOS's Home App displays the right state (opening, closing, idle)
+    var target_position = this.current_position;
+    if (state === 1) target_position = 100;
+    else if (state === 0) target_position = 0;
+
+    if (this.get_target_position_callbacks.length > 0) {
+        this.get_target_position_callbacks.forEach(function (callback) {
+            callback(null, target_position);
+        }.bind(this));
+        this.log('Responded to ' + this.get_target_position_callbacks.length + ' TargetPosition callbacks!');
+        this.get_target_position_callbacks = [];
+    }
+}
+
 MinimalisticHttpBlinds.prototype.update_current_state = function() {
     request({
         url: this.get_current_state_url,
@@ -120,10 +170,14 @@ MinimalisticHttpBlinds.prototype.update_current_state = function() {
         if (error) {
             this.log('Error when polling current state.');
             this.log(error);
+            this.complete_get_current_state_callbacks(this.current_state);
+            this.complete_get_target_position_callbacks(this.current_state);
             return;
         }
         else if (response.statusCode != this.get_current_state_expected_response_code) {
             this.log('Unexpected HTTP status code when polling current state. Got: ' + response.statusCode + ', expected:' + this.get_current_state_expected_response_code);
+            this.complete_get_current_state_callbacks(this.current_state);
+            this.complete_get_target_position_callbacks(this.current_state);
             return;
         }
 
@@ -133,31 +187,15 @@ MinimalisticHttpBlinds.prototype.update_current_state = function() {
             this.notify_ios_blinds_has_stopped = true;
 
         if (this.get_current_state_callbacks.length > 0) {
-            this.get_current_state_callbacks.forEach(function (callback) {
-                callback(null, new_state);
-            }.bind(this));
-            this.log('Responded to ' + this.get_current_state_callbacks.length + ' PositionState callbacks!');
-            this.get_current_state_callbacks = [];
+            this.complete_get_current_state_callbacks(new_state);
         }
         else if (new_state !== this.current_state) {
             // Sooo, yeah... We're updating PositionState, but iOS doesn't care anyway... we still do it for the lolz.
             this.service.getCharacteristic(Characteristic.PositionState).setValue(new_state);
             this.log('Updated PositionState to value ' + new_state);
         }
-
-        // This is ugly: we're faking the target position to either 0, 100 or the current position,
-        // so that iOS's Home App displays the right state (opening, closing, idle)
-        var target_position = this.current_position;
-        if (new_state === 1) target_position = 100;
-        else if (new_state === 0) target_position = 0;
-
-        if (this.get_target_position_callbacks.length > 0) {
-            this.get_target_position_callbacks.forEach(function (callback) {
-                callback(null, target_position);
-            }.bind(this));
-            this.log('Responded to ' + this.get_target_position_callbacks.length + ' TargetPosition callbacks!');
-            this.get_target_position_callbacks = [];
-        }
+        
+        this.complete_get_target_position_callbacks(this.new_state);
 
         this.current_state = new_state;
     }.bind(this));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-minimal-http-blinds",
   "description": "Minimalistic HTTP blinds management *that supports percentages* for diy-ish projects.",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "repository": {
     "type": "git",
     "url": "git://github.com/Nicnl/homebridge-minimal-http-blinds.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-minimal-http-blinds",
   "description": "Minimalistic HTTP blinds management *that supports percentages* for diy-ish projects.",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "repository": {
     "type": "git",
     "url": "git://github.com/Nicnl/homebridge-minimal-http-blinds.git"


### PR DESCRIPTION
Should address https://github.com/Nicnl/homebridge-minimal-http-blinds/issues/5
The problem was 2 fold.
1. The state callbacks broke after a timeout due to a copy paste error.
    1. Addressed via not manually scheduling callbacks to occur and just set them to repeat. (removed typo)
1. If the webserver was down, iphone would not go onto next device in bridge due to callbacks only getting completed on success (unsure if it eventually times out and does)
    1. Addressed by calling completion callbacks with cached data on error.

Lastly I added a feature that if there is no app (60 seconds) activity to immediately return cached results. This fits my usage pattern where I have a longer polling intervals and also fixes longer initial load times if the webserver is down and a timeout has to first occur.

Lastly updated docs & bumped package version.

I know of no known regressions introduced.