### PR TITLE
add returning errors to callbacks & caching for errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-minimal-http-blinds",
   "description": "Minimalistic HTTP blinds management *that supports percentages* for diy-ish projects.",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "repository": {
     "type": "git",
     "url": "git://github.com/Nicnl/homebridge-minimal-http-blinds.git"


### PR DESCRIPTION
Allows home app to know blinds are misbehaving.
Addresses issue https://github.com/Nicnl/homebridge-minimal-http-blinds/issues/9 .

Adds 
1. returning errors to all callbacks.
1. caching of errors.

Inspired from example https://github.com/nfarina/homebridge/blob/6500912f54a70ff479e63e2b72760ab589fa558a/example-plugins/homebridge-lockitron/index.js#L75